### PR TITLE
sync: pass along MIN_MAJOR_VERSION env var

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - redpanda:/mnt/redpanda
     environment:
       - CLOUDSMITH_API_KEY=${CLOUDSMITH_API_KEY}
+      - MIN_MAJOR_VERSION=${MIN_MAJOR_VERSION}
 
   caddy:
     build: ./caddy


### PR DESCRIPTION
jira: [DEVPROD-2428]

when docker compose launches containers, pass along the env var `MIN_MAJOR_VERSION` to `sync/main.py` so it can be used to restrict packages to download.

[DEVPROD-2428]: https://redpandadata.atlassian.net/browse/DEVPROD-2428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ